### PR TITLE
Fix pricing comment wording

### DIFF
--- a/src/libs/Anthropic/Metadata/Metadata.Chat.cs
+++ b/src/libs/Anthropic/Metadata/Metadata.Chat.cs
@@ -4,7 +4,7 @@ namespace Anthropic;
 public static partial class ModelMetadata
 {
     /// <summary>
-    /// According https://anthropic.com/pricing#anthropic-api <br/>
+    /// According to https://anthropic.com/pricing#anthropic-api <br/>
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>

--- a/src/libs/Anthropic/Metadata/Metadata.cs
+++ b/src/libs/Anthropic/Metadata/Metadata.cs
@@ -2,7 +2,7 @@
 namespace Anthropic;
 
 /// <summary>
-/// According https://anthropic.com/pricing#anthropic-api
+/// According to https://anthropic.com/pricing#anthropic-api
 /// </summary>
 public static partial class ModelMetadata
 {


### PR DESCRIPTION
## Summary
- correct a typo in pricing references for `Metadata` and `Metadata.Chat`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6851bc21c1b88325ab365fd88afa1a69