### PR TITLE
Update SSE comment

### DIFF
--- a/src/libs/Anthropic/AnthropicClient.Streaming.cs
+++ b/src/libs/Anthropic/AnthropicClient.Streaming.cs
@@ -142,7 +142,7 @@ public partial class AnthropicClient
                            .EnumerateAsync(cancellationToken)
                            .ConfigureAwait(false))
         {
-            // When the response is good, each line is a serializable CompletionCreateRequest
+            // When the response is good, each SSE line contains a serialized MessageStreamEvent
             var block = JsonSerializer.Deserialize(sseEvent.Data, SourceGenerationContext.Default.NullableMessageStreamEvent);
             if (block == null)
             {


### PR DESCRIPTION
## Summary
- adjust comment to indicate each SSE line contains a serialized `MessageStreamEvent`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6851bc470cd88325958fe5b5742cb6a0